### PR TITLE
Fix ImportError by updating dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ django-debug-toolbar==4.2.0
 django-filter==23.3
 django-rest-framework==0.1.0
 djangorestframework==3.14.0
-djangorestframework-simplejwt==5.3.0
+djangorestframework-simplejwt==5.3.1
 drf-spectacular==0.26.5
 flake8==6.1.0
 inflection==0.5.1


### PR DESCRIPTION
I installed the dependencies from the `requirements.txt` file using (i use uv package manager):
```sh
uv pip install -r requirements.txt
```
After running the server i got this error:
```sh
File "/home/arabov/Projects/python/social-media-api/venv/lib/python3.10/site-packages/rest_framework/settings.py", line 180, in import_from_string
    raise ImportError(msg)
ImportError: Could not import 'rest_framework_simplejwt.authentication.JWTAuthentication' for API setting 'DEFAULT_AUTHENTICATION_CLASSES'. ModuleNotFoundError: No module named 'pkg_resources'.
```
I followed this [Stack Overflow answer](https://stackoverflow.com/questions/57864306/importerror-could-not-import-rest-framework-simplejwt-authentication-jwtauthen), which suggested updating the packages. This solved the issue:

```sh
uv pip install --upgrade djangorestframework-simplejwt
```